### PR TITLE
Install gecode from RBEL packages on RHEL distros.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,7 +19,7 @@
 #
 
 case node['platform']
-when 'debian', 'ubuntu'
+when 'centos', 'debian', 'redhat', 'scientific', 'ubuntu'
   default['gecode']['install_method'] = 'package'
 else
   default['gecode']['install_method'] = 'source'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -44,6 +44,19 @@ when 'ubuntu','debian'
   apt_package 'libgecode-dev' do
     action :upgrade
   end
+when 'centos', 'redhat', 'scientific'
+
+  platform_release = node[:platform_version].to_f.floor
+
+  yum_repository 'rbel' do
+    name "rbel#{platform_release}"
+    url "http://rbel.co/rbel#{platform_release}"
+    description 'Ruby and Opscode Chef packages for RHEL distributions'
+    action :add
+  end
+
+  package 'gecode'
+  package 'gecode-devel'
 
 else
   raise "This recipe does not yet support installing Gecode 3.5.0+ from packages on your platform"

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -38,22 +38,3 @@ bash "build gecode from source" do
   EOH
   not_if { ::File.exists?("/usr/local/lib/#{lib_name}") }
 end
-
-# configure the dynamic linker, redhat only
-case node['platform']
-when 'centos', 'redhat', 'fedora'
-  directory "/etc/ld.so.conf.d/" do
-    owner "root"
-    group "root"
-    mode 0755
-  end
-  execute "ldconfig" do
-    command "ldconfig"
-    action :nothing
-  end
-
-  file "/etc/ld.so.conf.d/gecode.conf" do
-    content "/usr/local/lib "
-    notifies :run, "execute[ldconfig]"
-  end
-end


### PR DESCRIPTION
It is unnecessary to build gecode from source now that RBEL hosts
RPM repositories with gecode packages for RHEL 5 and RHEL 6 systems.
